### PR TITLE
add simple xmake support + instructions for making use of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ A header only library of utility functions spun off from CommonLibSSE
  
  + simpleINI.hpp
     + convenient [SimpleINI](https://github.com/brofield/simpleini) value getter and setter
+
+## xmake support:
+
+you need to use ClibUtil as submodule like this:
+```
+git submodule add https://github.com/powerof3/CLibUtil extern/clib-util
+```
+
+in your xmake.lua:
+
+```lua
+includes("extern/clib-util")
+```
+and in target:
+```lua
+add_deps("clib-util")
+```
+

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,4 @@
+target("clib-util")
+    set_kind("headeronly")
+    add_headerfiles("include/**.h")
+    add_includedirs("include", {public = true})

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,4 +1,4 @@
 target("clib-util")
     set_kind("headeronly")
-    add_headerfiles("include/**.h")
+    add_headerfiles("include/**.h", "include/**.hpp")
     add_includedirs("include", {public = true})


### PR DESCRIPTION
this only adds a simple xmake.lua for ease of use with xmake. 
it should not affect cmake in any way and won't require you to maintain it any further. 
