### PR TITLE
add ignore move keys bool to KeyCombination.Process 

### DIFF
--- a/include/CLIBUtil/hotkeys.hpp
+++ b/include/CLIBUtil/hotkeys.hpp
@@ -225,7 +225,6 @@ namespace clib_util::hotkeys
 			}
 
 			std::set<Key> pressed;
-			bool donotinsert = false;
 			for (auto event = *a_event; event; event = event->next) {
 				auto button = event->AsButtonEvent();
 				if (!button || !button->HasIDCode()) {
@@ -249,11 +248,11 @@ namespace clib_util::hotkeys
 				{
 					if (key == 17 || key == 30 || key == 31 || key == 32)
 					{
-						donotinsert = true;
+						continue;
 					}
 				}
 
-				if (button->IsPressed() && !donotinsert) {
+				if (button->IsPressed()) {
 					pressed.insert(key);
 				}
 			}

--- a/include/CLIBUtil/hotkeys.hpp
+++ b/include/CLIBUtil/hotkeys.hpp
@@ -254,7 +254,6 @@ namespace clib_util::hotkeys
 				}
 
 				if (button->IsPressed() && !donotinsert) {
-					SKSE::log::info("insert: {}", key);
 					pressed.insert(key);
 				}
 			}
@@ -306,7 +305,7 @@ namespace clib_util::hotkeys
 			this->pattern = string::join(rawKeys, " + ");
 			// Only non-empty KeyCombinations should be considered valid.
 			// However, we want to allow setting empty patterns to unbind given KeyCombination easily.
-			isValid = !keys.empty(); 
+			isValid = !keys.empty();
 			return true;
 		}
 

--- a/include/CLIBUtil/hotkeys.hpp
+++ b/include/CLIBUtil/hotkeys.hpp
@@ -218,13 +218,14 @@ namespace clib_util::hotkeys
 			this->pattern = string::join(rawKeys, " + ");
 		}
 
-		bool Process(RE::InputEvent* const* a_event)
+		bool Process(RE::InputEvent* const* a_event, const bool a_ignoreMoveKeysOnKeyboard = false)
 		{
 			if (!isValid) {
 				return false;
 			}
 
 			std::set<Key> pressed;
+			bool donotinsert = false;
 			for (auto event = *a_event; event; event = event->next) {
 				auto button = event->AsButtonEvent();
 				if (!button || !button->HasIDCode()) {
@@ -244,10 +245,20 @@ namespace clib_util::hotkeys
 					break;
 				}
 
-				if (button->IsPressed()) {
+				if (a_ignoreMoveKeysOnKeyboard)
+				{
+					if (key == 17 || key == 30 || key == 31 || key == 32)
+					{
+						donotinsert = true;
+					}
+				}
+
+				if (button->IsPressed() && !donotinsert) {
+					SKSE::log::info("insert: {}", key);
 					pressed.insert(key);
 				}
 			}
+
 
 			if (pressed == keys) {
 				if (!alreadyTriggered) {


### PR DESCRIPTION
this allows KeyCombos to execute even tho a 3rd key (the direction) is pressed which otherwise makes the KeyCombo invalid
i added a default = false to it so if not needed, you don't have to pass the bool