### PR TITLE
Use REX::W32 instead of relying on windows.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	CLibUtil
-	VERSION 1.4.8
+	VERSION 1.4.9
 	LANGUAGES CXX
 )
 

--- a/include/CLIBUtil/editorID.hpp
+++ b/include/CLIBUtil/editorID.hpp
@@ -38,8 +38,8 @@ namespace clib_util::editorID
 			return a_form->GetFormEditorID();
 		default:
 			{
-				static auto tweaks = GetModuleHandleA("po3_Tweaks.dll");
-				static auto func = reinterpret_cast<_GetFormEditorID>(GetProcAddress(tweaks, "GetFormEditorID"));
+				static auto tweaks = REX::W32::GetModuleHandleW(L"po3_Tweaks.dll");
+				static auto func = reinterpret_cast<_GetFormEditorID>(REX::W32::GetProcAddress(tweaks, "GetFormEditorID"));
 				if (func) {
 					return func(a_form->formID);
 				}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clib-util",
-  "version-string": "1.4.8",
+  "version-string": "1.4.9",
   "homepage": "https://github.com/powerof3/CLibUtil",
   "license": "MIT",
   "dependencies": []


### PR DESCRIPTION
- Changed GetModuleHandleA in editorID.hpp to REX::W32::GetModuleHandleW
  - Used wide string instead
- Bumped version from 1.4.8 to 1.4.9